### PR TITLE
make JSON writing optional

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -47,7 +47,8 @@ let
   buildResources = {
     configuration ? {},
     resourceFilter ? groupName: name: resource: true,
-    withDependencies ? true
+    withDependencies ? true,
+    writeJSON ? true
   }: let
     evaldConfiguration = evalKubernetesModules configuration;
 
@@ -96,7 +97,12 @@ let
         metadata.labels."kubenix/build" = listHash;
       }) kubernetesList.items;
     };
-  in pkgs.writeText "resources.json" (builtins.toJSON hashedList);
+
+    result = if writeJSON then
+      pkgs.writeText "resources.json" (builtins.toJSON hashedList)
+      else hashedList;
+  in
+    result;
 
   buildTest = test: version: buildResources {
     configuration = {


### PR DESCRIPTION
allow to pass `writeJSON = false;` and get the raw data instead.

This is useful if one wants to avoid writing secrets in the /nix/store. It also speeds up the rendering quite a bit. 

Eg:

./render.sh
```sh
#!/usr/bin/env bash
set -euo pipefail

imageTag=foobar

toYAML() {
  ruby -ryaml -rjson -e 'puts YAML.dump(JSON.load(ARGF))'
}

nix-instantiate ./default.nix \
  --eval --strict --json \
  --argstr imageTag "$imageTag" \
  | toYAML 
```

default.nix
```nix
{ imageTag ? "latest" }:
let
  # where kubenix is added as an overlay
  pkgs = import ../nix {};

  configuration = import ./configuration.nix { inherit imageTag; };

  manifest = pkgs.kubenix.buildResources {
    inherit configuration;
    writeJSON = false;
  };
in
  manifest
```