### PR TITLE
Make writing SHA1 hashes optional

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,7 +48,8 @@ let
     configuration ? {},
     resourceFilter ? groupName: name: resource: true,
     withDependencies ? true,
-    writeJSON ? true
+    writeJSON ? true,
+    writeHash ? true
   }: let
     evaldConfiguration = evalKubernetesModules configuration;
 
@@ -91,7 +92,7 @@ let
 
     listHash = builtins.hashString "sha1" (builtins.toJSON kubernetesList);
 
-    hashedList = kubernetesList // {
+    hashedList = kubernetesList // optionalAttrs (writeHash) {
       labels."kubenix/build" = listHash;
       items = map (resource: recursiveUpdate resource {
         metadata.labels."kubenix/build" = listHash;


### PR DESCRIPTION
Sometimes we find that we simply do not need the SHA1 hashes embedded into the documents.
This makes printing them optional but keeps the default to `on`