### PR TITLE
fix crontabs -> cronTabs in tests/k8s/crd.nix

### DIFF
--- a/tests/k8s/crd.nix
+++ b/tests/k8s/crd.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   crd = config.kubernetes.api.resources.customResourceDefinitions.crontabs;
-  latestCrontab = config.kubernetes.api.resources.crontabs.latest;
+  latestCrontab = config.kubernetes.api.resources.cronTabs.latest;
 in {
   imports = with kubenix.modules; [ test k8s ];
 


### PR DESCRIPTION
must have been missed in recent refactor (086780088cce40c1bda897136ebdf06b2f684d1c)

discovered while trying to run tests with:
```
nix-build release.nix -A test-results --show-trace
```

after this fix I can see another error (below), but don't have the time to investigate further.

```
...
while evaluating anonymous function at /Users/adriangierakowski/SourceCode/3nder/kubenix/modules/k8s.nix:132:64, called from /nix/store/hvf28w7kjlmsxysfpwjx39sghchswbvv-nixpkgs-20.03pre199926.d901b961a95/nixpkgs/lib/attrsets.nix:234:16:
while evaluating the attribute 'attrName' at undefined position:
while evaluating anonymous function at /nix/store/hvf28w7kjlmsxysfpwjx39sghchswbvv-nixpkgs-20.03pre199926.d901b961a95/nixpkgs/lib/modules.nix:75:45, called from undefined position:
while evaluating the attribute 'value' at /nix/store/hvf28w7kjlmsxysfpwjx39sghchswbvv-nixpkgs-20.03pre199926.d901b961a95/nixpkgs/lib/modules.nix:336:9:
while evaluating the option `kubernetes.customTypes.stable.example.com/v1/CronTab.attrName':
The option `kubernetes.customTypes.stable.example.com/v1/CronTab.attrName' is used but not defined
```

